### PR TITLE
テキスト検索のインデックスをタブにした

### DIFF
--- a/app/controllers/stanza_search_controller.rb
+++ b/app/controllers/stanza_search_controller.rb
@@ -1,6 +1,5 @@
 class StanzaSearchController < ApplicationController
-  def index(q, category)
-    @category = category
+  def index(q)
     @stanzas  = StanzaSearch.search(q)
   rescue => ex
     @error = ex

--- a/app/controllers/stanza_search_controller.rb
+++ b/app/controllers/stanza_search_controller.rb
@@ -1,6 +1,6 @@
 class StanzaSearchController < ApplicationController
   def index(q, category)
-    @category = category || 'all'
+    @category = category
     @stanzas  = StanzaSearch.search(q)
   rescue => ex
     @error = ex

--- a/app/controllers/stanza_search_controller.rb
+++ b/app/controllers/stanza_search_controller.rb
@@ -1,6 +1,7 @@
 class StanzaSearchController < ApplicationController
   def index(q, category)
-    @stanzas = StanzaSearch.search_by_category(q, category)
+    @category = category || 'all'
+    @stanzas  = StanzaSearch.search(q)
   rescue => ex
     @error = ex
   end

--- a/app/controllers/stanza_search_controller.rb
+++ b/app/controllers/stanza_search_controller.rb
@@ -1,6 +1,6 @@
 class StanzaSearchController < ApplicationController
   def index(q)
-    @stanzas  = StanzaSearch.search(q)
+    @stanzas = StanzaSearch.search(q)
   rescue => ex
     @error = ex
   end

--- a/app/helpers/stanza_search_helper.rb
+++ b/app/helpers/stanza_search_helper.rb
@@ -39,10 +39,10 @@ module StanzaSearchHelper
     }
 
     [
-      ['Genes',        'gene_reports',        {'data-search-target' => 'category'}],
-      ['Organisms',    'organism_reports',    {'data-search-target' => 'category'}],
-      ['Environments', 'environment_reports', {'data-search-target' => 'category'}],
-      ['Phenotypes',   'phenotype_reports',   {'data-search-target' => 'category'}],
+      ['Genes',        'gene',        {'data-search-target' => 'category'}],
+      ['Organisms',    'organism',    {'data-search-target' => 'category'}],
+      ['Environments', 'environment', {'data-search-target' => 'category'}],
+      ['Phenotypes',   'phenotype',   {'data-search-target' => 'category'}],
       ['--------------', {disabled: 'disabled'}]
     ] + stanza_ary
   end

--- a/app/helpers/stanza_search_helper.rb
+++ b/app/helpers/stanza_search_helper.rb
@@ -39,7 +39,6 @@ module StanzaSearchHelper
     }
 
     [
-      ['All',          'all',                 {'data-search-target' => 'category'}],
       ['Genes',        'gene_reports',        {'data-search-target' => 'category'}],
       ['Organisms',    'organism_reports',    {'data-search-target' => 'category'}],
       ['Environments', 'environment_reports', {'data-search-target' => 'category'}],

--- a/app/helpers/stanza_search_helper.rb
+++ b/app/helpers/stanza_search_helper.rb
@@ -18,6 +18,9 @@ module StanzaSearchHelper
       when 'environments'
         env_id = stanza[:stanza_query]['env_id']
         ["Environment #{env_id}", environment_path(env_id)]
+      when 'phenotypes'
+        mpo_id = stanza[:stanza_query]['mpo_id']
+        ["Phenotype #{mpo_id}", phenotype_path(mpo_id)]
       end
 
     link_to(label, path, target: '_blank')
@@ -40,6 +43,7 @@ module StanzaSearchHelper
       ['Genes',        'gene_reports',        {'data-search-target' => 'category'}],
       ['Organisms',    'organism_reports',    {'data-search-target' => 'category'}],
       ['Environments', 'environment_reports', {'data-search-target' => 'category'}],
+      ['Phenotypes',   'phenotype_reports',   {'data-search-target' => 'category'}],
       ['--------------', {disabled: 'disabled'}]
     ] + stanza_ary
   end

--- a/app/models/stanza.rb
+++ b/app/models/stanza.rb
@@ -6,18 +6,6 @@ class Stanza < Settingslogic
     providers.togostanza.reject {|key| key == 'url' }.values.flatten.map {|s| s['id'] }
   end
 
-  def gene_ids
-    providers.togostanza.genes.map(&:id)
-  end
-
-  def organism_ids
-    providers.togostanza.organisms.map(&:id)
-  end
-
-  def env_ids
-    providers.togostanza.environments.map(&:id)
-  end
-
   def all
     providers.togostanza.reject {|key| key == 'url' }.flat_map {|report_type, stanzas|
       stanzas.map {|s| s.merge('report_type' => report_type) }

--- a/app/models/stanza_search.rb
+++ b/app/models/stanza_search.rb
@@ -5,6 +5,8 @@ class StanzaSearch
 
   class << self
     def search(q)
+      return nil unless q
+
       # XXX nanostanza は検索してない
       Stanza.ids.map {|id|
         search_by_stanza_id(q, id)

--- a/app/models/stanza_search.rb
+++ b/app/models/stanza_search.rb
@@ -4,9 +4,9 @@ class StanzaSearch
   PAGINATE = {per_page: 10}
 
   class << self
-    def search_by_category(q, category='all')
+    def search(q)
       # XXX nanostanza は検索してない
-      search_stanza_ids(category).map {|id|
+      Stanza.ids.map {|id|
         search_by_stanza_id(q, id)
       }.group_by {|e|
         e[:report_type]
@@ -42,21 +42,6 @@ class StanzaSearch
       # 「件数取得」と「検索結果取得」で2回同じ検索が行われるのでキャッシュしておく
       Rails.cache.fetch Digest::MD5.hexdigest(url), expires_in: 1.day, compress: true do
         open(url).read
-      end
-    end
-
-    def search_stanza_ids(key)
-      case key
-      when 'all'
-        Stanza.ids
-      when 'gene_reports'
-        Stanza.gene_ids
-      when 'organism_reports'
-        Stanza.organism_ids
-      when 'environment_reports'
-        Stanza.env_ids
-      else
-        []
       end
     end
   end

--- a/app/views/stanza_search/index.html.haml
+++ b/app/views/stanza_search/index.html.haml
@@ -18,14 +18,38 @@
       .alert.alert-error
         = @error
     - unless @stanzas.blank?
-      %table#results.table.table-striped.table-bordered.table-condensed
-        %thead
-          %td Gene
-          %td Organism
-          %td Environments
-          %td Phenotypes
-        %tr
-          %td= render 'count_list', query: params[:q], stanzas: @stanzas['genes']
-          %td= render 'count_list', query: params[:q], stanzas: @stanzas['organisms']
-          %td= render 'count_list', query: params[:q], stanzas: @stanzas['environments']
-          %td= render 'count_list', query: params[:q], stanzas: @stanzas['phenotypes']
+      %ul.nav.nav-tabs
+        %li.active
+          %a{href: '#all', data: {toggle: :tab, category: :all}} All
+        %li
+          %a{href: '#gene', data: {toggle: :tab, category: :gene_reports}} Gene
+        %li
+          %a{href: '#organism', data: {toggle: :tab, category: :organism_reports}} Organism
+        %li
+          %a{href: '#environment', data: {toggle: :tab, category: :environment_reports}} Environment
+
+      .tab-content
+        #all.tab-pane.active
+          .span3
+            = render 'count_list', query: params[:q], stanzas: @stanzas['genes']
+          .span3
+            = render 'count_list', query: params[:q], stanzas: @stanzas['organisms']
+          .span3
+            = render 'count_list', query: params[:q], stanzas: @stanzas['environments']
+
+        #gene.tab-pane
+          = render 'count_list', query: params[:q], stanzas: @stanzas['genes']
+        #organism.tab-pane
+          = render 'count_list', query: params[:q], stanzas: @stanzas['organisms']
+        #environment.tab-pane
+          = render 'count_list', query: params[:q], stanzas: @stanzas['environments']
+
+:coffeescript
+  $ ->
+    # セレクトボックスで選択され描画された場合、その選択したタブを開く
+    $("a[data-category='#{@category}']").tab('show')
+
+    # タブを選択すると、セレクトボックスもそれを追随して選択する
+    $('.nav-tabs a').on "click", (e) ->
+      category =  $(e.target).data('category')
+      $("select#category").val(category)

--- a/app/views/stanza_search/index.html.haml
+++ b/app/views/stanza_search/index.html.haml
@@ -17,7 +17,7 @@
     - if @error
       .alert.alert-error
         = @error
-    - unless @stanzas.blank?
+    - if @stanzas
       %ul.nav.nav-tabs
         %li.active
           %a{href: '#all', data: {toggle: :tab, category: :all}} All

--- a/app/views/stanza_search/index.html.haml
+++ b/app/views/stanza_search/index.html.haml
@@ -29,9 +29,7 @@
             = render 'count_list', query: params[:q], stanzas: @stanzas[type.pluralize]
 
 :javascript
-  $(function() {
-    return '.nav-tabs a'.on("click", function(e) {
-      var category = $(e.target).data('category');
-      return $("select#category").val(category);
-    });
+  $('.nav-tabs a').on("click", function(e) {
+    var category = $(e.target).data('category');
+    return $("select#category").val(category);
   });

--- a/app/views/stanza_search/index.html.haml
+++ b/app/views/stanza_search/index.html.haml
@@ -20,29 +20,23 @@
     - if @stanzas
       %ul.nav.nav-tabs
         %li.active
-          %a{href: '#all', data: {toggle: :tab, category: :all}} All
-        %li
           %a{href: '#gene', data: {toggle: :tab, category: :gene_reports}} Gene
         %li
           %a{href: '#organism', data: {toggle: :tab, category: :organism_reports}} Organism
         %li
           %a{href: '#environment', data: {toggle: :tab, category: :environment_reports}} Environment
+        %li
+          %a{href: '#phenotype', data: {toggle: :tab, category: :phenotype_reports}} Phenotype
 
       .tab-content
-        #all.tab-pane.active
-          .span3
-            = render 'count_list', query: params[:q], stanzas: @stanzas['genes']
-          .span3
-            = render 'count_list', query: params[:q], stanzas: @stanzas['organisms']
-          .span3
-            = render 'count_list', query: params[:q], stanzas: @stanzas['environments']
-
-        #gene.tab-pane
+        #gene.tab-pane.active
           = render 'count_list', query: params[:q], stanzas: @stanzas['genes']
         #organism.tab-pane
           = render 'count_list', query: params[:q], stanzas: @stanzas['organisms']
         #environment.tab-pane
           = render 'count_list', query: params[:q], stanzas: @stanzas['environments']
+        #phenotype.tab-pane
+          = render 'count_list', query: params[:q], stanzas: @stanzas['phenotypes']
 
 :coffeescript
   $ ->

--- a/app/views/stanza_search/index.html.haml
+++ b/app/views/stanza_search/index.html.haml
@@ -41,7 +41,7 @@
 :coffeescript
   $ ->
     # セレクトボックスで選択され描画された場合、その選択したタブを開く
-    $("a[data-category='#{@category}']").tab('show')
+    $("a[data-category='#{params[:category]}']").tab('show')
 
     # タブを選択すると、セレクトボックスもそれを追随して選択する
     $('.nav-tabs a').on "click", (e) ->

--- a/app/views/stanza_search/index.html.haml
+++ b/app/views/stanza_search/index.html.haml
@@ -19,31 +19,19 @@
         = @error
     - if @stanzas
       %ul.nav.nav-tabs
-        %li.active
-          %a{href: '#gene', data: {toggle: :tab, category: :gene_reports}} Gene
-        %li
-          %a{href: '#organism', data: {toggle: :tab, category: :organism_reports}} Organism
-        %li
-          %a{href: '#environment', data: {toggle: :tab, category: :environment_reports}} Environment
-        %li
-          %a{href: '#phenotype', data: {toggle: :tab, category: :phenotype_reports}} Phenotype
+        - %w(gene organism environment phenotype).each do |type|
+          %li{class: "#{'active' if params[:category] == type}"}
+            %a{href: "##{type}", data: {toggle: :tab, category: type.to_sym}}= type.capitalize
 
       .tab-content
-        #gene.tab-pane.active
-          = render 'count_list', query: params[:q], stanzas: @stanzas['genes']
-        #organism.tab-pane
-          = render 'count_list', query: params[:q], stanzas: @stanzas['organisms']
-        #environment.tab-pane
-          = render 'count_list', query: params[:q], stanzas: @stanzas['environments']
-        #phenotype.tab-pane
-          = render 'count_list', query: params[:q], stanzas: @stanzas['phenotypes']
+        - %w(gene organism environment phenotype).each do |type|
+          .tab-pane{id: type, class: "#{'active' if params[:category] == type}"}
+            = render 'count_list', query: params[:q], stanzas: @stanzas[type.pluralize]
 
-:coffeescript
-  $ ->
-    # セレクトボックスで選択され描画された場合、その選択したタブを開く
-    $("a[data-category='#{params[:category]}']").tab('show')
-
-    # タブを選択すると、セレクトボックスもそれを追随して選択する
-    $('.nav-tabs a').on "click", (e) ->
-      category =  $(e.target).data('category')
-      $("select#category").val(category)
+:javascript
+  $(function() {
+    return '.nav-tabs a'.on("click", function(e) {
+      var category = $(e.target).data('category');
+      return $("select#category").val(category);
+    });
+  });

--- a/app/views/stanza_search/index.html.haml
+++ b/app/views/stanza_search/index.html.haml
@@ -20,12 +20,12 @@
     - if @stanzas
       %ul.nav.nav-tabs
         - %w(gene organism environment phenotype).each do |type|
-          %li{class: "#{'active' if params[:category] == type}"}
+          %li{class: params[:category] == type ? 'active' : nil}
             %a{href: "##{type}", data: {toggle: :tab, category: type.to_sym}}= type.capitalize
 
       .tab-content
         - %w(gene organism environment phenotype).each do |type|
-          .tab-pane{id: type, class: "#{'active' if params[:category] == type}"}
+          .tab-pane{id: type, class: params[:category] == type ? 'active' : nil}
             = render 'count_list', query: params[:q], stanzas: @stanzas[type.pluralize]
 
 :javascript


### PR DESCRIPTION
## 概要

- レポートタイプ毎のタブに分けた
- セレクトボックスとタブを連動するようにした
- All は無くした

## 画面イメージ

![togogenome](https://cloud.githubusercontent.com/assets/83493/5499454/5023379c-8773-11e4-8650-a9830b9900cd.png)
