### PR TITLE
Sequence 検索のタブ化

### DIFF
--- a/app/controllers/sequence_controller.rb
+++ b/app/controllers/sequence_controller.rb
@@ -3,9 +3,9 @@ class SequenceController < ApplicationController
   end
 
   def search(fragment)
-    gggenome_response = Sequence.search_gggenome(fragment.delete("\s\n"))
-    @sequences = Sequence.append_sequence_ontologies(gggenome_response)
-    @organisms = Sequence.append_organisms(gggenome_response)
+    sequence = fragment.delete("\s\n")
+    @sequences = Sequence.search_sequence_ontologies(sequence)
+    @organisms = Sequence.search_organisms(sequence)
   rescue => ex
     @error = ex
   ensure

--- a/app/controllers/sequence_controller.rb
+++ b/app/controllers/sequence_controller.rb
@@ -3,7 +3,9 @@ class SequenceController < ApplicationController
   end
 
   def search(fragment)
-    @sequences = Sequence.search(fragment.delete("\s\n"))
+    gggenome_response = Sequence.search_gggenome(fragment.delete("\s\n"))
+    @sequences = Sequence.append_sequence_ontologies(gggenome_response)
+    @organisms = Sequence.append_organisms(gggenome_response)
   rescue => ex
     @error = ex
   ensure

--- a/app/models/gggenome_search.rb
+++ b/app/models/gggenome_search.rb
@@ -12,7 +12,7 @@ class GggenomeSearch
 
       raise StandardError, "[GGGenome Error] #{gggenome[:error]}" unless gggenome[:error] == 'none'
 
-      gggenome[:results].map {|r| OpenStruct.new(r)}
+      gggenome[:results].map {|r| OpenStruct.new(r) }
     end
   end
 end

--- a/app/models/gggenome_search.rb
+++ b/app/models/gggenome_search.rb
@@ -1,0 +1,18 @@
+require 'ostruct'
+
+class GggenomeSearch
+  class << self
+    def search(sequence, url = 'http://gggenome.dbcls.jp/prok', format = 'json')
+      result = Rails.cache.fetch Digest::MD5.hexdigest(sequence), expires_in: 1.day do
+        client = HTTPClient.new
+        client.get_content("#{url}/#{sequence}.#{format}")
+      end
+
+      gggenome = JSON.parse(result, {symbolize_names: true})
+
+      raise StandardError, "[GGGenome Error] #{gggenome[:error]}" unless gggenome[:error] == 'none'
+
+      gggenome[:results].map {|r| OpenStruct.new(r)}
+    end
+  end
+end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -4,21 +4,23 @@ class Sequence
   include Queryable
 
   class << self
-    def search(sequence)
-      gggenome_response = search_gggenome(sequence)
+    def search_gggenome(sequence, url = 'http://gggenome.dbcls.jp/prok', format = 'json')
+      client = HTTPClient.new
+      ret = client.get_content("#{url}/#{sequence}.#{format}")
+      gggenome = JSON.parse(ret, {symbolize_names: true})
 
-      raise StandardError, "[GGGenome Error] #{gggenome_response[:error]}" unless gggenome_response[:error] == 'none'
+      raise StandardError, "[GGGenome Error] #{gggenome[:error]}" unless gggenome[:error] == 'none'
 
-      append_togogenome_attributes(gggenome_response)
+      gggenome[:results]
     end
 
-    def append_togogenome_attributes(gggenome_response)
-      sparqls = build_sparqls(gggenome_response)
+    def append_sequence_ontologies(gggenome)
+      sparqls = build_sequence_ontologies_sparqls(gggenome)
       sparql_results = sparqls.flat_map {|sparql|
         result = query(sparql)
       }
 
-      gggenome_response[:results].map do |genome|
+      gggenome.map do |genome|
         so = sparql_results.select {|r| r[:name] == genome[:name] }
         genome.merge(
           sequence_ontologies: so.map {|r| {uri: r[:sequence_ontology], name: r[:sequence_ontology_name]}},
@@ -28,19 +30,25 @@ class Sequence
       end
     end
 
-    private
+    def append_organisms(gggenome)
+      sparqls = build_organisms_sparqls(gggenome)
+      sparql_results = sparqls.flat_map {|sparql|
+        result = query(sparql)
+      }
 
-    def search_gggenome(sequence, url = 'http://gggenome.dbcls.jp/prok', format = 'json')
-      client = HTTPClient.new
-      ret = client.get_content("#{url}/#{sequence}.#{format}")
-      JSON.parse(ret, {symbolize_names: true})
+      sparql_results.map do |results|
+        sequence_count = gggenome.select {|g| g[:taxonomy].to_s == results[:taxonomy_id] }.count
+        results.merge(sequence_count: sequence_count)
+      end
     end
 
-    def build_sparqls(gggenome_response)
+    private
+
+    def build_sequence_ontologies_sparqls(gggenome)
       # slice の理由
       # gggenome での検索結果が多い時、それらをまとめて1つのSPARQL にすると、
       # SPARQLのサーバで 'error code 414: uri too large' にひっかかってしまうため Query を分割している
-      gggenome_response[:results].each_slice(300).map do |sub_results|
+      gggenome.each_slice(300).map do |sub_results|
         <<-SPARQL.strip_heredoc
           DEFINE sql:select-option "order"
           #{SPARQLUtil::PREFIX[:insdc]}
@@ -54,7 +62,7 @@ class Sequence
               SELECT DISTINCT ?name ?sequence_ontology ?sequence_ontology_name ?feature
               WHERE {
                 VALUES (?name ?position ?position_end ?refseq ?strand ) {
-                  #{bind_values(sub_results)}
+                  #{bind_sequence_ontologies_values(sub_results)}
                 }
                 ?refseq_uri insdc:sequence_version ?refseq .
                 ?refseq_uri insdc:sequence ?sequence .
@@ -78,11 +86,44 @@ class Sequence
       end
     end
 
-    def bind_values(genomes)
+    def build_organisms_sparqls(gggenome)
+      # slice の理由
+      # gggenome での検索結果が多い時、それらをまとめて1つのSPARQL にすると、
+      # SPARQLのサーバで 'error code 414: uri too large' にひっかかってしまうため Query を分割している
+      gggenome.each_slice(300).map do |sub_results|
+        <<-SPARQL.strip_heredoc
+          DEFINE sql:select-option "order"
+          PREFIX tax: <http://identifiers.org/taxonomy/>
+          SELECT DISTINCT (REPLACE(STR(?taxonomy),"http://identifiers.org/taxonomy/","") AS ?taxonomy_id) ?taxonomy_name ?category ?category_name ?sub_category ?sub_category_name
+          FROM #{SPARQLUtil::ONTOLOGY[:taxonomy]}
+          WHERE {
+              VALUES ?taxonomy  {
+                  #{bind_organisms_values(sub_results)}
+              }
+              ?taxonomy rdfs:label ?taxonomy_name .
+
+             ?taxonomy  rdfs:subClassOf* ?sub_category  .
+             ?category rdfs:subClassOf <http://identifiers.org/taxonomy/131567> .
+             ?sub_category rdfs:subClassOf ?category .
+
+             ?category rdfs:label ?category_name .
+             ?sub_category rdfs:label ?sub_category_name .
+          } ORDER BY ?category ?sub_category
+        SPARQL
+      end
+    end
+
+    def bind_sequence_ontologies_values(genomes)
       genomes.map {|genome|
         name, position, position_end, refseq, strand = genome.values_at(:name, :position, :position_end, :refseq, :strand)
         "( \"#{name}\" #{position} #{position_end} \"#{refseq}\" \"#{strand}\" )"
       }.join("\n")
+    end
+
+    def bind_organisms_values(genomes)
+     genomes.map {|genome|
+        "tax:#{genome[:taxonomy]}"
+      }.join(" ")
     end
   end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -8,14 +8,14 @@ class Sequence
       genomes = GggenomeSearch.search(sequence)
 
       sparqls = build_sequence_ontologies_sparqls(genomes)
-      sparql_results = sparqls.flat_map {|sparql| query(sparql) }
+      results = sparqls.flat_map {|sparql| query(sparql) }
 
       genomes.map do |genome|
-        so = sparql_results.select {|r| r[:name] == genome.name }
+        so = results.select {|r| r[:name] == genome.name }
         genome.to_h.merge(
-          sequence_ontologies: so.map {|r| {uri: r[:sequence_ontology], name: r[:sequence_ontology_name]}},
-          locus_tags: so.map {|r| r[:locus_tag]}.compact.uniq,
-          products: so.map {|r| r[:product]}.compact.uniq
+          sequence_ontologies: so.map {|r| {uri: r[:sequence_ontology], name: r[:sequence_ontology_name]} },
+          locus_tags: so.map {|r| r[:locus_tag] }.compact.uniq,
+          products: so.map {|r| r[:product] }.compact.uniq
         )
       end
     end
@@ -24,11 +24,11 @@ class Sequence
       genomes = GggenomeSearch.search(sequence)
 
       sparqls = build_organisms_sparqls(genomes)
-      sparql_results = sparqls.flat_map {|sparql| query(sparql) }
+      results = sparqls.flat_map {|sparql| query(sparql) }
 
-      sparql_results.map do |results|
-        sequence_count = genomes.select {|g| g.taxonomy.to_s == results[:taxonomy_id] }.count
-        results.merge(sequence_count: sequence_count)
+      results.map do |result|
+        sequence_count = genomes.select {|g| g.taxonomy.to_s == result[:taxonomy_id] }.count
+        result.merge(sequence_count: sequence_count)
       end
     end
 
@@ -110,9 +110,7 @@ class Sequence
     end
 
     def bind_organisms_values(genomes)
-     genomes.map {|genome|
-        "tax:#{genome.taxonomy}"
-      }.join(" ")
+     genomes.map {|genome| "tax:#{genome.taxonomy}" }.join(" ")
     end
   end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -37,10 +37,9 @@ class Sequence
     end
 
     def build_sparqls(gggenome_response)
-      # slice(100) の理由
-      # 1. gggenome での検索結果が多い時、それらをまとめて1つのSPARQL にすると、
-      #    SPARQLのサーバで 'error code 414: uri too large' にひっかかってしまうため Query を分割している
-      # 2. Endpoint 側(hhttp://ep.dbcls.jp/sparql7os) SPARQLに対してタイムアウトが発生し、エラーが帰って来た
+      # slice の理由
+      # gggenome での検索結果が多い時、それらをまとめて1つのSPARQL にすると、
+      # SPARQLのサーバで 'error code 414: uri too large' にひっかかってしまうため Query を分割している
       gggenome_response[:results].each_slice(300).map do |sub_results|
         <<-SPARQL.strip_heredoc
           DEFINE sql:select-option "order"

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -17,14 +17,17 @@ class Sequence
       sparql_results = sparqls.flat_map {|sparql|
         result = query(sparql)
       }
-      # GGGenome のレスポンスの中で、SPARQL で結果が返ってこなかったもの(= name が無いもの)を取得している
-      sparql_hits_refseqs =  sparql_results.map {|g| g[:name] }.uniq
 
-      sparql_not_hits_gggenome_results = gggenome_response['results'].reject {|genome|
-        sparql_hits_refseqs.include?(genome['name'])
-      }.map(&:symbolize_keys)
-
-      sparql_results + sparql_not_hits_gggenome_results
+      gggenome_response['results'].map do |genome|
+        so = sparql_results.select {|r| r[:name] == genome['name'] }
+        genome.merge(
+          {
+            'sequence_ontologies' => so.map {|r| {'uri' => r[:sequence_ontology], 'name' => r[:sequence_ontology_name]}},
+            'locus_tags'          => so.map {|r| r[:locus_tag]}.compact.uniq,
+            'products'            => so.map {|r| r[:product]}.compact.uniq
+          }
+        )
+      end
     end
 
     private
@@ -40,20 +43,20 @@ class Sequence
       # 1. gggenome での検索結果が多い時、それらをまとめて1つのSPARQL にすると、
       #    SPARQLのサーバで 'error code 414: uri too large' にひっかかってしまうため Query を分割している
       # 2. Endpoint 側(hhttp://ep.dbcls.jp/sparql7os) SPARQLに対してタイムアウトが発生し、エラーが帰って来た
-      gggenome_response['results'].each_slice(100).map do |sub_results|
+      gggenome_response['results'].each_slice(300).map do |sub_results|
         <<-SPARQL.strip_heredoc
           DEFINE sql:select-option "order"
           #{SPARQLUtil::PREFIX[:insdc]}
           #{SPARQLUtil::PREFIX[:faldo]}
           #{SPARQLUtil::PREFIX[:obo]}
-          SELECT DISTINCT ?locus_tag ?product ?sequence_ontology ?sequence_ontology_name ?taxonomy ?position ?name ?position_end ?snippet ?snippet_pos ?snippet_end
+          SELECT DISTINCT ?name ?sequence_ontology ?sequence_ontology_name ?locus_tag ?product
           FROM #{SPARQLUtil::ONTOLOGY[:so]}
           FROM #{SPARQLUtil::ONTOLOGY[:refseq]}
           WHERE {
             {
-              SELECT DISTINCT ?sequence_ontology ?sequence_ontology_name ?taxonomy ?position ?name ?position_end ?snippet ?snippet_pos ?snippet_end ?feature
+              SELECT DISTINCT ?name ?sequence_ontology ?sequence_ontology_name ?feature
               WHERE {
-                VALUES (?bioproject ?name ?position ?position_end ?refseq ?snippet ?snippet_end ?snippet_pos ?strand ?taxonomy) {
+                VALUES (?name ?position ?position_end ?refseq ?strand ) {
                   #{bind_values(sub_results)}
                 }
                 ?refseq_uri insdc:sequence_version ?refseq .
@@ -80,7 +83,7 @@ class Sequence
 
     def bind_values(genomes)
       genomes.map {|genome|
-        "( #{genome.map {|key, val| %w(position position_end).include?(key) ? "#{val}" : "\"#{val}\"" }.join(' ')} )"
+        "( #{genome.select {|k, _v| %w(name position position_end refseq strand).include?(k) }.map {|key, val| %w(position position_end).include?(key) ? "#{val}" : "\"#{val}\"" }.join(' ')} )"
       }.join("\n")
     end
   end

--- a/app/views/sequence/_organism_table.html.haml
+++ b/app/views/sequence/_organism_table.html.haml
@@ -1,0 +1,12 @@
+%table.table.table-striped.table-bordered.table-hover.table-condensed
+  %thead
+    %tr
+      %th Taxonomy
+      %th Organism
+      %th Sequence count
+  %tbody
+    - organisms.each do |organism|
+      %tr
+        %td= "#{organism[:category_name]} / #{organism[:sub_category_name]}"
+        %td= link_to organism[:taxonomy_name], organism_path(organism[:taxonomy_id]), target: '_blank'
+        %td= organism[:sequence_count]

--- a/app/views/sequence/_sequence_table.html.haml
+++ b/app/views/sequence/_sequence_table.html.haml
@@ -1,0 +1,32 @@
+%table.table.table-striped.table-bordered.table-hover.table-condensed
+  %thead
+    %tr
+      %th Sequence name
+      %th Locus tag
+      %th Product
+      %th Sequence ontology
+      %th Position begin
+      %th Position end
+      %th Sequence
+  %tbody
+    - sequences.each do |sequence|
+      %tr
+        %td= sequence[:name]
+        %td
+          - if sequence[:locus_tags].present?
+            %ul
+              - sequence[:locus_tags].each do |locus_tag|
+                %li= link_to locus_tag, gene_path("#{sequence[:taxonomy]}:#{locus_tag}"), target: '_blank'
+        %td
+          - if sequence[:products].present?
+            %ul
+              - sequence[:products].each do |product|
+                %li= product
+        %td
+          - if sequence[:sequence_ontologies].present?
+            %ul
+              - sequence[:sequence_ontologies].each do |so|
+                %li= link_to so[:name], so[:uri], target: '_blank'
+        %td.numeric= number_with_delimiter(sequence[:position])
+        %td.numeric= number_with_delimiter(sequence[:position_end])
+        %td= match_snippet(sequence[:snippet], sequence[:snippet_pos], sequence[:position], sequence[:position_end])

--- a/app/views/sequence/index.html.haml
+++ b/app/views/sequence/index.html.haml
@@ -30,10 +30,22 @@
         %tbody
           - @sequences.each do |sequence|
             %tr
-              %td= sequence[:name]
-              %td= link_to sequence[:locus_tag], gene_path("#{sequence[:taxonomy]}:#{sequence[:locus_tag]}"), target: '_blank' if sequence[:locus_tag]
-              %td= sequence[:product] if sequence[:product]
-              %td= link_to sequence[:sequence_ontology_name], sequence[:sequence_ontology], target: '_blank' if sequence[:sequence_ontology_name]
-              %td.numeric= number_with_delimiter(sequence[:position])
-              %td.numeric= number_with_delimiter(sequence[:position_end])
-              %td= match_snippet(sequence[:snippet], sequence[:snippet_pos], sequence[:position], sequence[:position_end])
+              %td= sequence['name']
+              %td
+                - if sequence['locus_tags'].present?
+                  %ul
+                    - sequence['locus_tags'].each do |locus_tag|
+                      %li= link_to locus_tag, gene_path("#{sequence['taxonomy']}:#{locus_tag}"), target: '_blank'
+              %td
+                - if sequence['products'].present?
+                  %ul
+                    - sequence['products'].each do |product|
+                      %li= product
+              %td
+                - if sequence['sequence_ontologies'].present?
+                  %ul
+                    - sequence['sequence_ontologies'].each do |so|
+                      %li= link_to so['name'], so['uri'], target: '_blank'
+              %td.numeric= number_with_delimiter(sequence['position'])
+              %td.numeric= number_with_delimiter(sequence['position_end'])
+              %td= match_snippet(sequence['snippet'], sequence['snippet_pos'], sequence['position'], sequence['position_end'])

--- a/app/views/sequence/index.html.haml
+++ b/app/views/sequence/index.html.haml
@@ -16,7 +16,7 @@
     - if @error
       .alert.alert-error
         = @error
-    - else
+    - elsif params[:fragment]
       %ul.nav.nav-tabs
         %li.active
           %a{href: "#sequence", data: {toggle: :tab}} Sequence

--- a/app/views/sequence/index.html.haml
+++ b/app/views/sequence/index.html.haml
@@ -30,22 +30,22 @@
         %tbody
           - @sequences.each do |sequence|
             %tr
-              %td= sequence['name']
+              %td= sequence[:name]
               %td
-                - if sequence['locus_tags'].present?
+                - if sequence[:locus_tags].present?
                   %ul
-                    - sequence['locus_tags'].each do |locus_tag|
-                      %li= link_to locus_tag, gene_path("#{sequence['taxonomy']}:#{locus_tag}"), target: '_blank'
+                    - sequence[:locus_tags].each do |locus_tag|
+                      %li= link_to locus_tag, gene_path("#{sequence[:taxonomy]}:#{locus_tag}"), target: '_blank'
               %td
-                - if sequence['products'].present?
+                - if sequence[:products].present?
                   %ul
-                    - sequence['products'].each do |product|
+                    - sequence[:products].each do |product|
                       %li= product
               %td
-                - if sequence['sequence_ontologies'].present?
+                - if sequence[:sequence_ontologies].present?
                   %ul
-                    - sequence['sequence_ontologies'].each do |so|
-                      %li= link_to so['name'], so['uri'], target: '_blank'
-              %td.numeric= number_with_delimiter(sequence['position'])
-              %td.numeric= number_with_delimiter(sequence['position_end'])
-              %td= match_snippet(sequence['snippet'], sequence['snippet_pos'], sequence['position'], sequence['position_end'])
+                    - sequence[:sequence_ontologies].each do |so|
+                      %li= link_to so[:name], so[:uri], target: '_blank'
+              %td.numeric= number_with_delimiter(sequence[:position])
+              %td.numeric= number_with_delimiter(sequence[:position_end])
+              %td= match_snippet(sequence[:snippet], sequence[:snippet_pos], sequence[:position], sequence[:position_end])

--- a/app/views/sequence/index.html.haml
+++ b/app/views/sequence/index.html.haml
@@ -16,36 +16,21 @@
     - if @error
       .alert.alert-error
         = @error
-    - unless @sequences.blank?
-      %table.table.table-striped.table-bordered.table-hover.table-condensed
-        %thead
-          %tr
-            %th Sequence name
-            %th Locus tag
-            %th Product
-            %th Sequence ontology
-            %th Position begin
-            %th Position end
-            %th Sequence
-        %tbody
-          - @sequences.each do |sequence|
-            %tr
-              %td= sequence[:name]
-              %td
-                - if sequence[:locus_tags].present?
-                  %ul
-                    - sequence[:locus_tags].each do |locus_tag|
-                      %li= link_to locus_tag, gene_path("#{sequence[:taxonomy]}:#{locus_tag}"), target: '_blank'
-              %td
-                - if sequence[:products].present?
-                  %ul
-                    - sequence[:products].each do |product|
-                      %li= product
-              %td
-                - if sequence[:sequence_ontologies].present?
-                  %ul
-                    - sequence[:sequence_ontologies].each do |so|
-                      %li= link_to so[:name], so[:uri], target: '_blank'
-              %td.numeric= number_with_delimiter(sequence[:position])
-              %td.numeric= number_with_delimiter(sequence[:position_end])
-              %td= match_snippet(sequence[:snippet], sequence[:snippet_pos], sequence[:position], sequence[:position_end])
+    - else
+      %ul.nav.nav-tabs
+        %li.active
+          %a{href: "#sequence", data: {toggle: :tab}} Sequence
+        %li
+          %a{href: "#organism", data: {toggle: :tab}} Organism
+
+      .tab-content
+        #sequence.tab-pane.active
+          - if @sequences.present?
+            = render 'sequence_table', sequences: @sequences
+          - else
+            Not found.
+        #organism.tab-pane
+          - if @organisms.present?
+            = render 'organism_table', organisms: @organisms
+          - else
+            Not found.


### PR DESCRIPTION
- Sequence タブ: Sequence name 毎に１行にして、Locus tag, Product, Sequence ontology はリストで出すようにしました
- Organism タブ: Taxonomy(カテゴリーのトップ2階層), Organism , Sequence count(Organism にヒットした 配列の数) を出すようにしました
