### PR TITLE
GGGenome API を修正した

### DIFF
--- a/app/controllers/api/gggenome_controller.rb
+++ b/app/controllers/api/gggenome_controller.rb
@@ -1,50 +1,21 @@
 class Api::GggenomeController < ApplicationController
   def show(gggenome)
-    gggenome_keys = gggenome['results'].first.keys
+    genomes = gggenome['results'].map {|r| OpenStruct.new(r) }
+    sparqls = Sequence.build_sequence_ontologies_sparqls(genomes)
+    sparql_results = sparqls.flat_map {|sparql| Sequence.query(sparql) }
 
-    result = Genome.append_togogenome_attributes(gggenome).map {|binding|
-      # GGGenomeの値は キー名と"value"の値のハッシュで表示、togogenome(EP) から取得した値は、"togogenome" キー以下に キー名と"value"の値のハッシュで表示するように
-      # ==== Examples
-      #  {"position"=>{"type"=>"typed-literal", "datatype"=>"http://www.w3.org/2001/XMLSchema#integer", "value"=>"7480"},
-      #   "locus_tag"=>{"type"=>"literal", "value"=>"slr1311"},
-      #   "position_end"=>{"type"=>"typed-literal", "datatype"=>"http://www.w3.org/2001/XMLSchema#integer", "value"=>"7496"},
-      #   "strand"=>{"type"=>"literal", "value"=>"+"},
-      #   "refseq"=>{"type"=>"literal", "value"=>"NC_000911.1"},
-      #   "snippet_end"=>{"type"=>"literal", "value"=>"7596"},
-      #   "snippet"=>{"type"=>"literal", "value"=>"CCTTCATCGCCGCTCCCCCCGTTGACATCGACGGTATCCGTGAGCCCGTTGCTGGTTCTTTGCTTTACGGTAACAACATCATCTCTGGTGCTGTTGTACCTTCTTCCAACGCTATCGGTTTGCACTTCTACCCCATCTGGGAAGCCGCTTCCTTAGATGAGTGGTTGTACAACGGTGGTCCTTACCAGTTGGTAGTATTCCACTTCCTCATCGGCAT"},
-      #   "feature_position_beg"=>{"type"=>"typed-literal", "datatype"=>"http://www.w3.org/2001/XMLSchema#integer", "value"=>"7229"},
-      #   "sequence_ontology"=>{"type"=>"uri", "value"=>"http://purl.obolibrary.org/obo/SO_0000704"},
-      #   "feature_position_end"=>{"type"=>"typed-literal", "datatype"=>"http://www.w3.org/2001/XMLSchema#integer", "value"=>"8311"},
-      #   "snippet_pos"=>{"type"=>"literal", "value"=>"7380"},
-      #   "name"=>{"type"=>"literal", "value"=>"Synechocystis sp. PCC 6803 chromosome, complete genome."},
-      #   "taxonomy"=>{"type"=>"literal", "value"=>"1148"},
-      #   "bioproject"=>{"type"=>"literal", "value"=>"PRJNA57659"}
-      #  }
-      #
-      #  #=> {"position":"7480",
-      #       "togogenome":{"locus_tag":"slr1311",
-      #                     "feature_position_beg":"7229",
-      #                     "sequence_ontology":"http://purl.obolibrary.org/obo/SO_0000704",
-      #                     "feature_position_end":"8311"},
-      #       "position_end":"7496",
-      #       "strand":"+",
-      #       "refseq":"NC_000911.1",
-      #       "snippet_end":"7596",
-      #       "snippet":"CCTTCATCGCCGCTCCCCCCGTTGACATCGACGGTATCCGTGAGCCCGTTGCTGGTTCTTTGCTTTACGGTAACAACATCATCTCTGGTGCTGTTGTACCTTCTTCCAACGCTATCGGTTTGCACTTCTACCCCATCTGGGAAGCCGCTTCCTTAGATGAGTGGTTGTACAACGGTGGTCCTTACCAGTTGGTAGTATTCCACTTCCTCATCGGCAT",
-      #       "snippet_pos":"7380",
-      #       "name":"Synechocystis sp. PCC 6803 chromosome, complete genome.",
-      #       "taxonomy":"1148",
-      #       "bioproject":"PRJNA57659"
-      #       }
-      binding.each_with_object({}) {|(name, term), hash|
-        if gggenome_keys.include?(name.to_s)
-          hash[name] = term
-        else
-          (hash['togogenome'] ||= {})[name] = term
-        end
-      }
-    }
+    results = genomes.map do |genome|
+      so = sparql_results.select {|r| r[:name] == genome.name }
 
-    render json: result
+      genome.to_h.merge(
+        togogenome: {
+          sequence_ontologies: so.map {|r| {uri: r[:sequence_ontology], name: r[:sequence_ontology_name]} },
+          locus_tags: so.map {|r| r[:locus_tag] }.compact.uniq,
+          products: so.map {|r| r[:product] }.compact.uniq
+        }
+      )
+    end
+
+    render json: results
   end
 end

--- a/app/models/sequence.rb
+++ b/app/models/sequence.rb
@@ -32,8 +32,6 @@ class Sequence
       end
     end
 
-    private
-
     def build_sequence_ontologies_sparqls(gggenome)
       # slice の理由
       # gggenome での検索結果が多い時、それらをまとめて1つのSPARQL にすると、
@@ -75,6 +73,8 @@ class Sequence
         SPARQL
       end
     end
+
+    private
 
     def build_organisms_sparqls(gggenome)
       # slice の理由


### PR DESCRIPTION
Sequence 検索の機能拡張に追随し、Sequence タブで表示するために取得している SPARQL 結果を返すようにした