### PR TITLE
データスキーマ変更にともなう SPARQL の変更

### DIFF
--- a/app/views/sparql_templates/report_type/environments/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/environments/has_go_condition.rq.erb
@@ -38,13 +38,13 @@ WHERE {
   }
   GRAPH <%= ontology[:goup] %> {
     <% unless bp_id.empty? %>
-      <http://purl.uniprot.org/go/<%= bp_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= bp_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless mf_id.empty? %>
-      <http://purl.uniprot.org/go/<%= mf_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= mf_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless cc_id.empty? %>
-      <http://purl.uniprot.org/go/<%= cc_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= cc_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
   }
 } <%= order_clause %> LIMIT <%= limit %> OFFSET <%= offset %>

--- a/app/views/sparql_templates/report_type/genes/gene_ontologies.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/gene_ontologies.rq.erb
@@ -15,12 +15,11 @@ WHERE {
   GRAPH <%= ontology[:uniprot] %> {
     ?uniprot_up rdf:type <http://purl.uniprot.org/core/Protein> .
     ?uniprot_up up:recommendedName/up:fullName ?recommended_name .
-    ?uniprot_up up:classifiedWith ?up_go_uri FILTER (STRSTARTS(STR(?up_go_uri), "http://purl.uniprot.org/go/")) .
-    ?up_go_uri a up:Concept .
+    ?uniprot_up up:classifiedWith ?obo_go_uri  .
+    ?obo_go_uri a owl:Class .
   }
 
-  BIND(IRI(REPLACE(STR(?up_go_uri),"http://purl.uniprot.org/go/","http://purl.obolibrary.org/obo/GO_", '')) AS ?obo_go_uri) .
-  BIND(IRI(REPLACE(STR(?up_go_uri),"http://purl.uniprot.org/go/","http://www.ebi.ac.uk/QuickGO/GTerm?id=GO:", '')) AS ?quick_go_uri) .
+  BIND(IRI(REPLACE(STR(?obo_go_uri),"http://purl.obolibrary.org/obo/GO_","http://www.ebi.ac.uk/QuickGO/GTerm?id=GO:", '')) AS ?quick_go_uri) .
   GRAPH <%= ontology[:go] %> { ?obo_go_uri rdfs:label ?go_name . }
   FILTER(LANG(?go_name) = "" || LANGMATCHES(LANG(?go_name), "en")) .
 }

--- a/app/views/sparql_templates/report_type/genes/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/has_go_condition.rq.erb
@@ -8,13 +8,13 @@ DEFINE sql:select-option "order"
 WHERE {
   GRAPH <%= ontology[:goup] %> {
     <% unless bp_id.empty? %>
-      <http://purl.uniprot.org/go/<%= bp_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= bp_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless mf_id.empty? %>
-      <http://purl.uniprot.org/go/<%= mf_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= mf_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless cc_id.empty? %>
-      <http://purl.uniprot.org/go/<%= cc_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= cc_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
   }
   GRAPH <%= ontology[:tgup] %> {

--- a/app/views/sparql_templates/report_type/organisms/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/organisms/has_go_condition.rq.erb
@@ -8,13 +8,13 @@ DEFINE sql:select-option "order"
 WHERE {
   GRAPH <%= ontology[:goup] %> {
     <% unless bp_id.empty? %>
-      <http://purl.uniprot.org/go/<%= bp_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= bp_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless mf_id.empty? %>
-      <http://purl.uniprot.org/go/<%= mf_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= mf_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless cc_id.empty? %>
-      <http://purl.uniprot.org/go/<%= cc_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= cc_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
   }
   GRAPH <%= ontology[:tgup] %> {

--- a/app/views/sparql_templates/report_type/phenotypes/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/phenotypes/has_go_condition.rq.erb
@@ -8,13 +8,13 @@ DEFINE sql:select-option "order"
 WHERE {
   GRAPH <%= ontology[:goup] %> {
     <% unless bp_id.empty? %>
-      <http://purl.uniprot.org/go/<%= bp_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= bp_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless mf_id.empty? %>
-      <http://purl.uniprot.org/go/<%= mf_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= mf_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
     <% unless cc_id.empty? %>
-      <http://purl.uniprot.org/go/<%= cc_id.split('/GO_').last %>> up:classifiedWith ?uniprot_id .
+      <<%= cc_id %>> up:classifiedWith ?uniprot_id .
     <% end %>
   }
   GRAPH <%= ontology[:tgup] %> {

--- a/spec/models/report_type/base_spec.rb
+++ b/spec/models/report_type/base_spec.rb
@@ -7,12 +7,12 @@ describe ReportType::Base do
     context "初期表示の場合" do
       context "Gene" do
         subject { ReportType::Gene.count() }
-        it { subject.should eq("1893802") }
+        it { subject.should eq("1724902") }
       end
 
       context "Organism" do
         subject { ReportType::Organism.count() }
-        it { subject.should eq("3189") }
+        it { subject.should eq("4110") }
       end
 
       context "Phenotype" do
@@ -47,7 +47,7 @@ describe ReportType::Base do
 
       context "Gene" do
         subject { ReportType::Gene.count(@args) }
-        it { subject.should eq("50") }
+        it { subject.should eq("48") }
       end
 
       context "Organism" do


### PR DESCRIPTION
- Uniprot のデータスキーマが少し変わった
- guup グラフの作り方が変更した?

```sql
PREFIX up: <http://purl.uniprot.org/core/>

SELECT DISTINCT ?uniprot_id
WHERE {
  GRAPH <http://togogenome.org/graph/goup> {
       <http://purl.uniprot.org/go/0034641>  up:classifiedWith ?uniprot_id .
  }
} LIMIT 10
```
と取れていたのが、取れなくなり、
```sql
PREFIX up: <http://purl.uniprot.org/core/>

SELECT DISTINCT ?uniprot_id
WHERE {
  GRAPH <http://togogenome.org/graph/goup> {
       <http://purl.obolibrary.org/obo/GO_0034641>  up:classifiedWith ?uniprot_id .
  }
} LIMIT 10
```
で取るようになったようなので対応しました。