### PR TITLE
テキスト検索の検索条件を保持するようにした

### DIFF
--- a/app/assets/javascripts/stanza_search.js.coffee
+++ b/app/assets/javascripts/stanza_search.js.coffee
@@ -1,7 +1,7 @@
 $ ->
-  saveTextSearchCondition = (selectTag) ->
+  saveTextSearchCondition = ->
     cond =
-      selectedValue: selectTag.find(':selected').val()
+      selectedValue: $('select#category').find(':selected').val()
       query: $('input#q').val()
 
     localStorage.setItem('textSearch', JSON.stringify(cond))
@@ -12,7 +12,7 @@ $ ->
     selectTag    = $('select#category')
     searchTarget = selectTag.find(':selected').data('searchTarget')
 
-    saveTextSearchCondition(selectTag)
+    saveTextSearchCondition()
 
     switch searchTarget
       when 'category'
@@ -27,7 +27,9 @@ $ ->
   $(window).on "load", (e) ->
     search = window.location.search
 
-    unless search
+    if search
+      saveTextSearchCondition()
+    else
       cond = JSON.parse(localStorage.getItem('textSearch'))
 
       if cond

--- a/app/assets/javascripts/stanza_search.js.coffee
+++ b/app/assets/javascripts/stanza_search.js.coffee
@@ -1,9 +1,19 @@
 $ ->
+  saveTextSearchCondition = (selectTag) ->
+    cond = {
+      selectedValue: selectTag.find(':selected').val()
+      query: $('input#q').val()
+    }
+
+    localStorage.setItem('textSearch', JSON.stringify(cond))
+
   $('form').on "submit", (e) ->
     e.preventDefault()
 
     selectTag    = $('select#category')
     searchTarget = selectTag.find(':selected').data('searchTarget')
+
+    saveTextSearchCondition(selectTag)
 
     switch searchTarget
       when 'category'

--- a/app/assets/javascripts/stanza_search.js.coffee
+++ b/app/assets/javascripts/stanza_search.js.coffee
@@ -1,9 +1,8 @@
 $ ->
   saveTextSearchCondition = (selectTag) ->
-    cond = {
+    cond =
       selectedValue: selectTag.find(':selected').val()
       query: $('input#q').val()
-    }
 
     localStorage.setItem('textSearch', JSON.stringify(cond))
 
@@ -24,3 +23,14 @@ $ ->
         selectTag.attr('name', 'stanza_id')
 
     @.submit()
+
+  $(window).on "load", (e) ->
+    search = window.location.search
+
+    unless search
+      cond = JSON.parse(localStorage.getItem('textSearch'))
+
+      if cond
+        $('input#q').val(cond.query)
+        $('select#category').val(cond.selectedValue)
+        $("#textsearch-container button").click()


### PR DESCRIPTION
- 検索時に入力したフィールドのテキストと選択した検索対象のレポートやスタンザを保持するようにした
- 他のページからテキスト検索ページを開いた時には、保持したデータを元に再度検索結果を提示するようにした