### PR TITLE
Fix sparql error

### DIFF
--- a/app/views/sparql_templates/report_type/environments/has_meo_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/environments/has_meo_condition.rq.erb
@@ -6,8 +6,9 @@ DEFINE sql:select-option "order"
 
 <%= select_clause %>
 WHERE {
-  GRAPH <%= ontology[:tgtax] %> { ?taxonomy_id rdfs:subClassOf <http://identifiers.org/taxonomy/131567>  }
   <% unless mpo_id.empty? %>
+    GRAPH <%= ontology[:tgtax] %> { ?taxonomy_id rdfs:subClassOf <http://identifiers.org/taxonomy/131567>  }
+
     VALUES ?p_meo { meo:MEO_0000437 meo:MEO_0000440 } .
     GRAPH <%= ontology[:mpo_descendants] %> { ?mpo_id rdfs:subClassOf <<%= mpo_id %>> }
     GRAPH <%= ontology[:gold] %> {


### PR DESCRIPTION
- MpoID を画面側の検索条件に用いた場合のみ ?taxonomy_id の絞り込みを使うようにした
- 元々のだと過負荷なクエリーのため SPARQLエラーになってしまっていた