### PR TITLE
ファセット検索の検索条件を保持するようにした

### DIFF
--- a/app/views/root/index.html.haml
+++ b/app/views/root/index.html.haml
@@ -112,6 +112,7 @@
         self.createNodesQueue = ancestor;
       }
 
+      // 表示時
       var facetCond = JSON.parse(localStorage.getItem(self.storageKey));
       if (facetCond) {
         self.formSet.id.val(facetCond.id);
@@ -264,6 +265,7 @@
 
       // セレクタ内の項目の選択
       self.selectItem = function($item, isNeedQuery) {
+
         // アイテムのハイライトの切り替え
         this.items[this.currentItem].removeClass(SELECTED);
         $item.addClass(SELECTED);
@@ -271,6 +273,38 @@
         // フィルタリング実行
         if (!isNeedQuery) return;
         var facetData = $item.get(0).facetData;
+
+        var baseNodeName = $node.find('.node-name').text();
+
+        var descriptionArr = [];
+        var ancestor = [];
+        var cond = JSON.parse(localStorage.getItem(self.facet.storageKey));
+
+        if (cond) {
+          descriptionArr = cond.description.split(' > ');
+          ancestor = cond.ancestor;
+        }
+
+        var index = descriptionArr.indexOf(baseNodeName);
+
+        if (index === -1 && baseNodeName !== 'All') {
+          var newAncestor = ancestor.concat(facetData.id);
+          var newDescription = descriptionArr.concat(facetData.name).join(' > ');
+        } else {
+          var newAncestor = ancestor.slice(0, index+1).concat(facetData.id);
+          var newDescription = descriptionArr.slice(0, index+1).concat(facetData.name).join(' > ');
+        }
+
+        var newCond = {
+          ancestor: newAncestor,
+          label: facetData.name,
+          value: facetData.name,
+          id: facetData.id,
+          description: newDescription
+        }
+
+        localStorage.setItem(self.facet.storageKey, JSON.stringify(newCond));
+
         this.facet.filtering(facetData.id, facetData.name);
       }
 

--- a/app/views/root/index.html.haml
+++ b/app/views/root/index.html.haml
@@ -42,39 +42,51 @@
       // 「Clear」ボタンへの登録
       facetAllClearButton.addClearButton(self.formSet.clear);
 
-      // フィルタリングの実行
-      self.filtering = function(id, name, $baseNode) {
+      // Facet 検索の保存
+      self.saveFacetCondition = function(condition) {
+        localStorage.setItem(self.storageKey, JSON.stringify(condition));
+      }
 
-        var baseNodeName = $baseNode.find('.node-name').text();
-        var descriptionArr = [];
-        var ancestor = [];
-        var cond = JSON.parse(localStorage.getItem(self.storageKey));
+      // Facet 検索の読み込み
+      self.loadFacetCondition = function() {
+        return JSON.parse(localStorage.getItem(self.storageKey));
+      }
 
-        if (cond) {
-          descriptionArr = cond.description.split(' > ');
-          ancestor = cond.ancestor;
+      // Facet 階層操作による検索条件の更新
+      self.updateFacetCondition = function(id, name, $baseNode) {
+        var baseNodeName = $baseNode.find('.node-name').text(),
+            hierarchy_symbol = ' > ',
+            newDescriptionArr = [],
+            newAncestor = [],
+            facetCond = self.loadFacetCondition();
+
+        if (facetCond) {
+          newDescriptionArr = facetCond.description.split(hierarchy_symbol);
+          newAncestor = facetCond.ancestor;
         }
 
-        var index = descriptionArr.indexOf(baseNodeName);
-
-        if (index === -1 && baseNodeName !== 'All') {
-          var newAncestor = ancestor.concat(id);
-          var newDescription = descriptionArr.concat(name).join(' > ');
-        } else {
-          var newAncestor = ancestor.slice(0, index+1).concat(id);
-          var newDescription = descriptionArr.slice(0, index+1).concat(name).join(' > ');
+        // 'hydrosphere > water > fresh water' が 'hydrosphere > water > sea water' に変わる時は、
+        // 'hydrosphere > water' まででスライスし、後で 'sea water' を追加する
+        var index = newDescriptionArr.indexOf(baseNodeName);
+        if (index > -1 || baseNodeName === 'All') {
+          newDescriptionArr = newDescriptionArr.slice(0, index + 1);
+          newAncestor = newAncestor.slice(0, index + 1);
         }
 
         var newCond = {
-          ancestor: newAncestor,
+          id: id,
           label: name,
           value: name,
-          id: id,
-          description: newDescription
+          description: newDescriptionArr.concat(name).join(hierarchy_symbol),
+          ancestor: newAncestor.concat(id)
         }
 
-        localStorage.setItem(self.storageKey, JSON.stringify(newCond));
+        self.saveFacetCondition(newCond);
+      }
 
+      // フィルタリングの実行
+      self.filtering = function(id, name, $baseNode) {
+        self.updateFacetCondition(id, name, $baseNode);
         self.formSet.target.val(name);
         self.formSet.id.val(id);
         self.toggle_clear(true);
@@ -144,7 +156,7 @@
       }
 
       // 表示時
-      var facetCond = JSON.parse(localStorage.getItem(self.storageKey));
+      var facetCond = self.loadFacetCondition();
       if (facetCond) {
         self.formSet.id.val(facetCond.id);
         self.formSet.target.val(facetCond.label);
@@ -160,7 +172,7 @@
             $.getJSON(Routes.search_facet_path(self.key, {format: 'json'}), {word: $(this.element).val()}, response);
           },
           select: function(event, ui) {
-            localStorage.setItem(self.storageKey, JSON.stringify(ui.item));
+            self.saveFacetCondition(ui.item);
 
             self.formSet.id.val(ui.item.id);
             var ancestor = ui.item.ancestor;

--- a/app/views/root/index.html.haml
+++ b/app/views/root/index.html.haml
@@ -43,7 +43,38 @@
       facetAllClearButton.addClearButton(self.formSet.clear);
 
       // フィルタリングの実行
-      self.filtering = function(id, name) {
+      self.filtering = function(id, name, $baseNode) {
+
+        var baseNodeName = $baseNode.find('.node-name').text();
+        var descriptionArr = [];
+        var ancestor = [];
+        var cond = JSON.parse(localStorage.getItem(self.storageKey));
+
+        if (cond) {
+          descriptionArr = cond.description.split(' > ');
+          ancestor = cond.ancestor;
+        }
+
+        var index = descriptionArr.indexOf(baseNodeName);
+
+        if (index === -1 && baseNodeName !== 'All') {
+          var newAncestor = ancestor.concat(id);
+          var newDescription = descriptionArr.concat(name).join(' > ');
+        } else {
+          var newAncestor = ancestor.slice(0, index+1).concat(id);
+          var newDescription = descriptionArr.slice(0, index+1).concat(name).join(' > ');
+        }
+
+        var newCond = {
+          ancestor: newAncestor,
+          label: name,
+          value: name,
+          id: id,
+          description: newDescription
+        }
+
+        localStorage.setItem(self.storageKey, JSON.stringify(newCond));
+
         self.formSet.target.val(name);
         self.formSet.id.val(id);
         self.toggle_clear(true);
@@ -200,7 +231,7 @@
         } else {
           // それ以外であれば、通常のフィルタリング
           createFacetNode($target, $parentNode, facetDatum, facet);
-          self.facet.filtering(facetDatum.id, facetDatum.name);
+          self.facet.filtering(facetDatum.id, facetDatum.name, $parentNode);
         }
       })
 
@@ -265,7 +296,6 @@
 
       // セレクタ内の項目の選択
       self.selectItem = function($item, isNeedQuery) {
-
         // アイテムのハイライトの切り替え
         this.items[this.currentItem].removeClass(SELECTED);
         $item.addClass(SELECTED);
@@ -274,38 +304,7 @@
         if (!isNeedQuery) return;
         var facetData = $item.get(0).facetData;
 
-        var baseNodeName = $node.find('.node-name').text();
-
-        var descriptionArr = [];
-        var ancestor = [];
-        var cond = JSON.parse(localStorage.getItem(self.facet.storageKey));
-
-        if (cond) {
-          descriptionArr = cond.description.split(' > ');
-          ancestor = cond.ancestor;
-        }
-
-        var index = descriptionArr.indexOf(baseNodeName);
-
-        if (index === -1 && baseNodeName !== 'All') {
-          var newAncestor = ancestor.concat(facetData.id);
-          var newDescription = descriptionArr.concat(facetData.name).join(' > ');
-        } else {
-          var newAncestor = ancestor.slice(0, index+1).concat(facetData.id);
-          var newDescription = descriptionArr.slice(0, index+1).concat(facetData.name).join(' > ');
-        }
-
-        var newCond = {
-          ancestor: newAncestor,
-          label: facetData.name,
-          value: facetData.name,
-          id: facetData.id,
-          description: newDescription
-        }
-
-        localStorage.setItem(self.facet.storageKey, JSON.stringify(newCond));
-
-        this.facet.filtering(facetData.id, facetData.name);
+        this.facet.filtering(facetData.id, facetData.name, $node);
       }
 
       // プルダウンメニューの生成

--- a/app/views/root/index.html.haml
+++ b/app/views/root/index.html.haml
@@ -27,6 +27,7 @@
       var self = $facet.get(0);
       self.$this = $facet;
       self.key = key;
+      self.storageKey = "facet_" + key;
       // ルートのファセットのデータ
       /// この変数いらないかも
       self.rootNodeData = facetDatum;
@@ -78,6 +79,8 @@
         self.toggle_clear(false);
         self.formSet.target.val('');
         self.formSet.id.val('');
+        localStorage.removeItem(self.storageKey);
+
         window.query();
         self.clearAllNodes();
       });
@@ -109,6 +112,14 @@
         self.createNodesQueue = ancestor;
       }
 
+      var facetCond = JSON.parse(localStorage.getItem(self.storageKey));
+      if (facetCond) {
+        self.formSet.id.val(facetCond.id);
+        self.formSet.target.val(facetCond.label);
+        self.createNodesQueue = facetCond.ancestor;
+        self.toggle_clear(true);
+      }
+
       // インクリメンタルサーチを実行する関数
       self.formSet.target
         .limitedcomplete({
@@ -117,6 +128,8 @@
             $.getJSON(Routes.search_facet_path(self.key, {format: 'json'}), {word: $(this.element).val()}, response);
           },
           select: function(event, ui) {
+            localStorage.setItem(self.storageKey, JSON.stringify(ui.item));
+
             self.formSet.id.val(ui.item.id);
             var ancestor = ui.item.ancestor;
             self.settlement(ancestor);


### PR DESCRIPTION
## 機能
- インクリメンタルサーチでのアイテム選択後に、検索するための情報(id, label, 階層ツリー)を対象ファセット毎にストアに保存する
- 同様に上位階層ノードの選択時、兄弟ノードの選択時にも、検索するための情報(id, label, 階層ツリー)を対象ファセット毎にストアに保存する
- ×ボタン、Allボタン押下時は、そのファセットについて保持している情報をストアから削除
- Clear ボタン押下時は、すべてのファセットについて保持している情報をストアから削除
- 画面ロード時に、ストアの内容を元に、ファセット内のフィールド入力しファセット内の階層を構築し、検索を実行し結果を表示する