### PR TITLE
stanza.yml のフォーマットを変更した

### DIFF
--- a/app/controllers/stanza_search_controller.rb
+++ b/app/controllers/stanza_search_controller.rb
@@ -12,6 +12,7 @@ class StanzaSearchController < ApplicationController
     stanzas = result[:urls].map {|url|
       {
         togogenome_url: url,
+        stanza_uri:     result[:stanza_uri],
         stanza_id:      result[:stanza_id],
         report_type:    result[:report_type],
         stanza_attr_id: url.split('/').last

--- a/app/helpers/stanza_search_helper.rb
+++ b/app/helpers/stanza_search_helper.rb
@@ -13,7 +13,7 @@ module StanzaSearchHelper
   end
 
   def stanza_prefix(stanza)
-    stanza_attr_id, report_type, stanza_id = stanza.values_at(:stanza_attr_id, :report_type, :stanza_id)
+    stanza_attr_id, report_type, stanza_id, stanza_uri = stanza.values_at(:stanza_attr_id, :report_type, :stanza_id, :stanza_uri)
 
     case report_type
     when 'genes'
@@ -25,7 +25,7 @@ module StanzaSearchHelper
       {stanza_tax_id: stanza_attr_id}
     when 'phenotypes'
       {stanza_mpo_id: stanza_attr_id}
-    end.merge(stanza: "#{Stanza.providers.togostanza.url}/#{stanza_id}")
+    end.merge(stanza: stanza_uri)
   end
 
   def stanza_collection

--- a/app/models/stanza.rb
+++ b/app/models/stanza.rb
@@ -3,12 +3,15 @@ class Stanza < Settingslogic
   namespace Rails.env
 
   def ids
-    providers.togostanza.reject {|key| key == 'url' }.values.flatten.map {|s| s['id'] }
+    providers.flat_map {|_report_type, stanzas| stanzas['togostanza'].map {|stanza| stanza['uri'].split('/').last } }
   end
 
   def all
-    providers.togostanza.reject {|key| key == 'url' }.flat_map {|report_type, stanzas|
-      stanzas.map {|s| s.merge('report_type' => report_type) }
+    providers.flat_map {|report_type, stanzas|
+      stanzas['togostanza'].map {|stanza|
+        id = stanza['uri'].split('/').last
+        stanza.merge('report_type' => report_type, 'id' => id, 'uri' => stanza['uri'])
+      }
     }
   end
 end

--- a/app/models/stanza_search.rb
+++ b/app/models/stanza_search.rb
@@ -77,12 +77,14 @@ class StanzaSearch
     def search_by_stanza_id(q, stanza_id, page = 1)
       stanza_data = Stanza.all.find {|s| s['id'] == stanza_id }
       result = get_with_cache(stanza_id, q, page)
+
       {
         enabled:     result.present?,
         urls:        (result ? result['response']['docs'].map {|doc| doc['@id']} : []),
         count:       (result ? result['response']['numFound'] : 0),
         stanza_id:   stanza_id,
         stanza_name: stanza_data['name'],
+        stanza_uri:  stanza_data['uri'],
         report_type: stanza_data['report_type']
       }
     end

--- a/app/views/environment/show.html.haml
+++ b/app/views/environment/show.html.haml
@@ -3,8 +3,8 @@
     #navbar.navbar
       .navbar-inner
         %ul.nav
-          - Stanza.providers.togostanza.environments.each do |stanza|
-            %li= link_to stanza.name, "##{stanza.id}"
+          - Stanza.providers.environments.togostanza.each do |stanza|
+            %li= link_to stanza.name, "##{stanza.uri.split('/').last}"
 
   #header.tg-report-header
     %p.tg-report-type Environment report
@@ -13,14 +13,14 @@
       %span#tg-title-label #{@environment.name}
 
   %section#nanostanzas.row-fluid
-    - Stanza.providers.nanostanza.environments.each do |stanza|
-      .nanostanza-container{data: {stanza: "#{Stanza.providers.nanostanza.url}/#{stanza.id}", stanza_meo_id: @meo_id, nanostanza_span: stanza.span}}
+    - Stanza.providers.environments.nanostanza.each do |stanza|
+      .nanostanza-container{data: {stanza: stanza.uri, stanza_meo_id: @meo_id, nanostanza_span: stanza.span}}
 
-  - Stanza.providers.togostanza.environments.each do |stanza|
-    %section{id: stanza.id}
+  - Stanza.providers.environments.togostanza.each do |stanza|
+    %section{id: stanza.uri.split('/').last}
       .page-header
         %h2= stanza.name
-      %div{data: {stanza: "#{Stanza.providers.togostanza.url}/#{stanza.id}", stanza_meo_id: @meo_id}}
+      %div{data: {stanza: stanza.uri, stanza_meo_id: @meo_id}}
 
 = content_for :javascript do
-  = javascript_include_tag "#{Stanza.providers.togostanza.url}/assets/stanza.js"
+  = javascript_include_tag "http://togostanza.org/stanza/assets/stanza.js"

--- a/app/views/gene/show.html.haml
+++ b/app/views/gene/show.html.haml
@@ -3,8 +3,8 @@
     #navbar.navbar
       .navbar-inner
         %ul.nav
-          - Stanza.providers.togostanza.genes.each do |stanza|
-            %li= link_to stanza.name, "##{stanza.id}"
+          - Stanza.providers.genes.togostanza.each do |stanza|
+            %li= link_to stanza.name, "##{stanza.uri.split('/').last}"
 
   #header.tg-report-header
     %p.tg-report-type Gene report
@@ -13,14 +13,14 @@
       %span#tg-title-label #{@gene.name}
 
   %section#nanostanzas.row-fluid
-    - Stanza.providers.nanostanza.genes.each do |stanza|
-      .nanostanza-container{data: {stanza: "#{Stanza.providers.nanostanza.url}/#{stanza.id}", stanza_tax_id: @tax_id, stanza_gene_id: @gene_id, nanostanza_span: stanza.span}}
+    - Stanza.providers.genes.nanostanza.each do |stanza|
+      .nanostanza-container{data: {stanza: stanza.uri, stanza_tax_id: @tax_id, stanza_gene_id: @gene_id, nanostanza_span: stanza.span}}
 
-  - Stanza.providers.togostanza.genes.each do |stanza|
-    %section{id: stanza.id}
+  - Stanza.providers.genes.togostanza.each do |stanza|
+    %section{id: stanza.uri.split('/').last}
       .page-header
         %h2= stanza.name
-      %div{data: {stanza: "#{Stanza.providers.togostanza.url}/#{stanza.id}", stanza_tax_id: @tax_id, stanza_gene_id: @gene_id}}
+      %div{data: {stanza: stanza.uri, stanza_tax_id: @tax_id, stanza_gene_id: @gene_id}}
 
 = content_for :javascript do
-  = javascript_include_tag "#{Stanza.providers.togostanza.url}/assets/stanza.js"
+  = javascript_include_tag "http://togostanza.org/stanza/assets/stanza.js"

--- a/app/views/organism/show.html.haml
+++ b/app/views/organism/show.html.haml
@@ -3,8 +3,8 @@
     #navbar.navbar
       .navbar-inner
         %ul.nav
-          - Stanza.providers.togostanza.organisms.each do |stanza|
-            %li= link_to stanza.name, "##{stanza.id}"
+          - Stanza.providers.organisms.togostanza.each do |stanza|
+            %li= link_to stanza.name, "##{stanza.uri.split('/').last}"
 
   #header.tg-report-header
     %p.tg-report-type Organism report
@@ -13,14 +13,14 @@
       %span#tg-title-label #{@organism.name}
 
   %section#nanostanzas.row-fluid
-    - Stanza.providers.nanostanza.organisms.each do |stanza|
-      .nanostanza-container{data: {stanza: "#{Stanza.providers.nanostanza.url}/#{stanza.id}", stanza_tax_id: @taxonomic_id, nanostanza_span: stanza.span}}
+    - Stanza.providers.organisms.nanostanza.each do |stanza|
+      .nanostanza-container{data: {stanza: stanza.uri, stanza_tax_id: @taxonomic_id, nanostanza_span: stanza.span}}
 
-  - Stanza.providers.togostanza.organisms.each do |stanza|
-    %section{id: stanza.id}
+  - Stanza.providers.organisms.togostanza.each do |stanza|
+    %section{id: stanza.uri.split('/').last}
       .page-header
         %h2= stanza.name
-      %div{data: {stanza: "#{Stanza.providers.togostanza.url}/#{stanza.id}", stanza_tax_id: @taxonomic_id}}
+      %div{data: {stanza: stanza.uri, stanza_tax_id: @taxonomic_id}}
 
 = content_for :javascript do
-  = javascript_include_tag "#{Stanza.providers.togostanza.url}/assets/stanza.js"
+  = javascript_include_tag "http://togostanza.org/stanza/assets/stanza.js"

--- a/app/views/phenotype/show.html.haml
+++ b/app/views/phenotype/show.html.haml
@@ -3,8 +3,8 @@
     #navbar.navbar
       .navbar-inner
         %ul.nav
-          - Stanza.providers.togostanza.phenotypes.each do |stanza|
-            %li= link_to stanza.name, "##{stanza.id}"
+          - Stanza.providers.phenotypes.togostanza.each do |stanza|
+            %li= link_to stanza.name, "##{stanza.uri.split('/').last}"
 
   #header.tg-report-header
     %p.tg-report-type Phenotype report
@@ -13,14 +13,14 @@
       %span#tg-title-label #{@phenotype.name}
 
   %section#nanostanzas.row-fluid
-    - Stanza.providers.nanostanza.phenotypes.each do |stanza|
-      .nanostanza-container{data: {stanza: "#{Stanza.providers.nanostanza.url}/#{stanza.id}", stanza_mpo_id: @phenotype_id, nanostanza_span: stanza.span}}
+    - Stanza.providers.phenotypes.nanostanza.each do |stanza|
+      .nanostanza-container{data: {stanza: stanza.uri, stanza_mpo_id: @phenotype_id, nanostanza_span: stanza.span}}
 
-  - Stanza.providers.togostanza.phenotypes.each do |stanza|
-    %section{id: stanza.id}
+  - Stanza.providers.phenotypes.togostanza.each do |stanza|
+    %section{id: stanza.uri.split('/').last}
       .page-header
         %h2= stanza.name
-      %div{data: {stanza: "#{Stanza.providers.togostanza.url}/#{stanza.id}", stanza_mpo_id: @phenotype_id}}
+      %div{data: {stanza: stanza.uri, stanza_mpo_id: @phenotype_id}}
 
 = content_for :javascript do
-  = javascript_include_tag "#{Stanza.providers.togostanza.url}/assets/stanza.js"
+  = javascript_include_tag "http://togostanza.org/stanza/assets/stanza.js"

--- a/app/views/stanza_search/show.html.haml
+++ b/app/views/stanza_search/show.html.haml
@@ -160,4 +160,4 @@
             }
 
       = content_for :javascript do
-        = javascript_include_tag "#{Stanza.providers.togostanza.url}/assets/stanza.js"
+        = javascript_include_tag "http://togostanza.org/stanza/assets/stanza.js"

--- a/config/stanza.yml.sample
+++ b/config/stanza.yml.sample
@@ -1,172 +1,170 @@
 defaults: &defaults
   providers:
-    togostanza:
-      url: http://localhost:9292/stanza
-      genes:
+    genes:
+      nanostanza:
         -
-          id:   protein_names
-          name: Protein names
-        -
-          id:   genome_jbrowse
-          name: Genomic context
-        -
-          id:   gene_attributes
-          name: Gene attributes
-        -
-          id:   nucleotide_sequence
-          name: Nucleotide sequence
-        -
-          id:   protein_attributes
-          name: Protein attributes
-        -
-          id:   protein_sequence
-          name: Protein sequence
-        -
-          id:   protein_general_annotation
-          name: Protein general annotation
-        -
-          id:   protein_ontologies
-          name: Protein ontologies
-        -
-          id:   protein_sequence_annotation
-          name: Protein sequence annotation
-        -
-          id:   protein_pfam_plot
-          name: Pfam plot
-        -
-          id:   protein_orthologs
-          name: Protein orthologs
-        -
-          id:   protein_references
-          name: Protein references
-        -
-          id:   protein_cross_references
-          name: Protein cross references
-
-      organisms:
-        -
-          id:   organism_names
-          name: Organism name
-        -
-          id:   genome_information
-          name: Genome information
-        -
-          id:   organism_jbrowse
-          name: Genomic context
-        -
-          id:   taxonomy_ortholog_profile
-          name: Ortholog profile
-        -
-          id:   lineage_information
-          name: Taxonomic information
-        -
-          id:   organism_culture_collections
-          name: Culture collections
-        -
-          id:   organism_medium_information
-          name: Medium information
-        -
-          id:   organism_phenotype
-          name: Phenotype information
-        -
-          id:   genome_plot
-          name: Genomic plot
-        -
-          id:   organism_pathogen_information
-          name: Pathogen information
-        -
-          id:   organism_cross_references
-          name: Organism cross references
-        -
-          id:   genome_cross_references
-          name: Genome cross references
-
-      environments:
-        -
-          id:   environment_attributes
-          name: Environment attributes
-        -
-          id:   environment_inhabitants_statistics
-          name: Inhabitants statistics
-        -
-          id:   environment_inhabitants
-          name: Inhabitants
-        -
-          id:   environment_geographical_map
-          name: Geographical map
-        -
-          id:   environment_taxonomic_composition
-          name: Taxonomic composition
-        -
-          id:   environment_environmental_ontology
-          name: Environmental ontology (MEO)
-
-      phenotypes:
-        -
-          id: microbial_phenotype_genus_composition
-          name: Genus List (Phenotype-based)
-        -
-          id: microbial_phenotype_environment_composition
-          name: Environment List (Phenotype-based)
-        -
-          id: microbial_phenotype_cell_shape
-          name: Shape Information
-        -
-          id: microbial_phenotype_information
-          name: Organism List
-
-    nanostanza:
-      url: http://localhost:9292/stanza
-      genes:
-        -
-          id: gene_length_nano
+          uri: http://togostanza.org/stanza/gene_length_nano
           span: 1
         -
-          id: protein_ec_number_nano
+          uri: http://togostanza.org/stanza/protein_ec_number_nano
           span: 1
         -
-          id: protein_3d_structure_nano
+          uri: http://togostanza.org/stanza/protein_3d_structure_nano
           span: 1
         -
-          id: protein_references_timeline_nano
+          uri: http://togostanza.org/stanza/protein_references_timeline_nano
           span: 2
 
-      organisms:
+      togostanza:
         -
-          id: organism_genome_size_nano
+          uri: http://togostanza.org/stanza/protein_names
+          name: Protein names
+        -
+          uri: http://togostanza.org/stanza/genome_jbrowse
+          name: Genomic context
+        -
+          uri: http://togostanza.org/stanza/gene_attributes
+          name: Gene attributes
+        -
+          uri: http://togostanza.org/stanza/nucleotide_sequence
+          name: Nucleotide sequence
+        -
+          uri: http://togostanza.org/stanza/protein_attributes
+          name: Protein attributes
+        -
+          uri: http://togostanza.org/stanza/protein_sequence
+          name: Protein sequence
+        -
+          uri: http://togostanza.org/stanza/protein_general_annotation
+          name: Protein general annotation
+        -
+          uri: http://togostanza.org/stanza/protein_ontologies
+          name: Protein ontologies
+        -
+          uri: http://togostanza.org/stanza/protein_sequence_annotation
+          name: Protein sequence annotation
+        -
+          uri: http://togostanza.org/stanza/protein_pfam_plot
+          name: Pfam plot
+        -
+          uri: http://togostanza.org/stanza/protein_orthologs
+          name: Protein orthologs
+        -
+          uri: http://togostanza.org/stanza/protein_references
+          name: Protein references
+        -
+          uri: http://togostanza.org/stanza/protein_cross_references
+          name: Protein cross references
+
+    organisms:
+      nanostanza:
+        -
+          uri: http://togostanza.org/stanza/organism_genome_size_nano
           span: 1
         -
-          id: organism_gene_number_nano
+          uri: http://togostanza.org/stanza/organism_gene_number_nano
           span: 1
         -
-          id: organism_gc_nano
+          uri: http://togostanza.org/stanza/organism_gc_nano
           span: 1
         -
-          id: organism_microbial_cell_shape_nano
+          uri: http://togostanza.org/stanza/organism_microbial_cell_shape_nano
           span: 1
         -
-          id: organism_ph_nano
+          uri: http://togostanza.org/stanza/organism_ph_nano
           span: 1
         -
-          id: organism_related_disease_nano
+          uri: http://togostanza.org/stanza/organism_related_disease_nano
           span: 1
 
+      togostanza:
+        -
+          uri: http://togostanza.org/stanza/organism_names
+          name: Organism name
+        -
+          uri: http://togostanza.org/stanza/genome_information
+          name: Genome information
+        -
+          uri: http://togostanza.org/stanza/organism_jbrowse
+          name: Genomic context
+        -
+          uri: http://togostanza.org/stanza/taxonomy_ortholog_profile
+          name: Ortholog profile
+        -
+          uri: http://togostanza.org/stanza/lineage_information
+          name: Taxonomic information
+        -
+          uri: http://togostanza.org/stanza/organism_culture_collections
+          name: Culture collections
+        -
+          uri: http://togostanza.org/stanza/organism_medium_information
+          name: Medium information
+        -
+          uri: http://togostanza.org/stanza/organism_phenotype
+          name: Phenotype information
+        -
+          uri: http://togostanza.org/stanza/genome_plot
+          name: Genomic plot
+        -
+          uri: http://togostanza.org/stanza/organism_pathogen_information
+          name: Pathogen information
+        -
+          uri: http://togostanza.org/stanza/organism_cross_references
+          name: Organism cross references
+        -
+          uri: http://togostanza.org/stanza/genome_cross_references
+          name: Genome cross references
 
-      environments:
+    environments:
+      nanostanza:
         -
-          id: environment_top_level_symbolic_image_nano
+          uri: http://togostanza.org/stanza/environment_top_level_symbolic_image_nano
           span: 1
         -
-          id: environment_inhabitants_statistics_nano
+          uri: http://togostanza.org/stanza/environment_inhabitants_statistics_nano
           span: 1
         -
-          id: environment_organism_distribution_on_temperature_nano
+          uri: http://togostanza.org/stanza/environment_organism_distribution_on_temperature_nano
           span: 1
         -
-          id: environment_organism_distribution_on_ph_nano
+          uri: http://togostanza.org/stanza/environment_organism_distribution_on_ph_nano
           span: 1
 
-      phenotypes: []
+      togostanza:
+        -
+          uri: http://togostanza.org/stanza/environment_attributes
+          name: Environment attributes
+        -
+          uri: http://togostanza.org/stanza/environment_inhabitants_statistics
+          name: Inhabitants statistics
+        -
+          uri: http://togostanza.org/stanza/environment_inhabitants
+          name: Inhabitants
+        -
+          uri: http://togostanza.org/stanza/environment_geographical_map
+          name: Geographical map
+        -
+          uri: http://togostanza.org/stanza/environment_taxonomic_composition
+          name: Taxonomic composition
+        -
+          uri: http://togostanza.org/stanza/environment_environmental_ontology
+          name: Environmental ontology (MEO)
+
+    phenotypes:
+      nanostanza: []
+      togostanza:
+        -
+          uri: http://togostanza.org/stanza/microbial_phenotype_genus_composition
+          name: Genus List (Phenotype-based)
+        -
+          uri: http://togostanza.org/stanza/microbial_phenotype_environment_composition
+          name: Environment List (Phenotype-based)
+        -
+          uri: http://togostanza.org/stanza/microbial_phenotype_cell_shape
+          name: Shape Information
+        -
+          uri: http://togostanza.org/stanza/microbial_phenotype_information
+          name: Organism List
 
 development:
   <<: *defaults


### PR DESCRIPTION
1つのレポートページに複数のスタンザプロバイダーの提供するスタンザを取り込めるように、
stanza.yml の構造を変更した。

その結果、旧来の stanza.yml からデータを取得していた箇所の修正を行なう必要があった
