### PR TITLE
Gene の一覧からタンパク質があるもののみという制約を辞めた

### DIFF
--- a/app/helpers/report_type_helper.rb
+++ b/app/helpers/report_type_helper.rb
@@ -1,7 +1,9 @@
 module ReportTypeHelper
   def list(items)
+    return nil if items.all?(&:nil?)
+
     content_tag(:ul) do
-      items.uniq.each do |item|
+      items.compact.uniq.each do |item|
         concat content_tag(:li, item)
       end
     end

--- a/app/models/report_type/gene.rb
+++ b/app/models/report_type/gene.rb
@@ -20,7 +20,7 @@ module ReportType
 
         return [] if results.empty?
 
-        genes = results.map {|b| "<#{b[:togogenome]}>" }.uniq.join(' ')
+        genes = results.map {|b| "<#{b[:togogenome]}>" }.uniq.join(', ')
 
         sparqls = [
           find_proteins_sparql(PREFIX, ONTOLOGY, genes),

--- a/app/views/sparql_templates/report_type/environments/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/environments/has_go_condition.rq.erb
@@ -35,6 +35,7 @@ WHERE {
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?taxonomy_id .
     ?togogenome rdfs:seeAlso ?uniprot_id .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
   GRAPH <%= ontology[:goup] %> {
     <% unless bp_id.empty? %>

--- a/app/views/sparql_templates/report_type/genes/gene_ontologies.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/gene_ontologies.rq.erb
@@ -6,7 +6,8 @@ FROM <%= ontology[:tgup] %>
 FROM <%= ontology[:uniprot] %>
 FROM <%= ontology[:go] %>
 WHERE {
-  VALUES ?gene { <%= genes %> }
+  ?gene skos:exactMatch ?refseq_gene .
+  FILTER (?gene IN( <%= genes %> ) )
   GRAPH <%= ontology[:tgup] %> {
   	?gene rdfs:seeAlso ?uniprot_id .
     ?uniprot_id rdf:type <http://identifiers.org/uniprot> .

--- a/app/views/sparql_templates/report_type/genes/gene_ontologies.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/gene_ontologies.rq.erb
@@ -14,7 +14,6 @@ WHERE {
   }
   GRAPH <%= ontology[:uniprot] %> {
     ?uniprot_up rdf:type <http://purl.uniprot.org/core/Protein> .
-    ?uniprot_up up:recommendedName/up:fullName ?recommended_name .
     ?uniprot_up up:classifiedWith ?obo_go_uri  .
     ?obo_go_uri a owl:Class .
   }

--- a/app/views/sparql_templates/report_type/genes/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/has_go_condition.rq.erb
@@ -20,9 +20,8 @@ WHERE {
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?uniprot_id .
     ?togogenome rdfs:seeAlso ?taxonomy_id .
-    ?uniprot_id rdfs:seeAlso ?uniprot_up .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
-  GRAPH <%= ontology[:uniprot] %> { ?uniprot_up up:recommendedName/up:fullName ?recommended_name }
   GRAPH <%= ontology[:taxonomy] %> { ?taxonomy_id rdfs:label ?taxonomy_name }
   <% if tax_id.present? %>
     GRAPH <%= ontology[:tgtax] %> { ?taxonomy_id rdfs:subClassOf <<%= tax_id %>> }

--- a/app/views/sparql_templates/report_type/genes/has_meo_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/has_meo_condition.rq.erb
@@ -2,7 +2,6 @@ DEFINE sql:select-option "order"
 <%= prefix[:mccv] %>
 <%= prefix[:meo] %>
 <%= prefix[:mpo] %>
-<%= prefix[:up] %>
 
 <%= select_clause %>
 WHERE {
@@ -21,8 +20,6 @@ WHERE {
   GRAPH <%= ontology[:taxonomy] %> { ?taxonomy_id rdfs:label ?taxonomy_name }
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?taxonomy_id .
-    ?togogenome rdfs:seeAlso ?uniprot_id .
-    ?uniprot_id rdfs:seeAlso ?uniprot_up .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
-  GRAPH <%= ontology[:uniprot] %> { ?uniprot_up up:recommendedName/up:fullName ?recommended_name }
 } LIMIT <%= limit %> OFFSET <%= offset %>

--- a/app/views/sparql_templates/report_type/genes/has_mpo_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/has_mpo_condition.rq.erb
@@ -2,7 +2,6 @@ DEFINE sql:select-option "order"
 <%= prefix[:mccv] %>
 <%= prefix[:meo] %>
 <%= prefix[:mpo] %>
-<%= prefix[:up] %>
 
 <%= select_clause %>
 WHERE {
@@ -12,8 +11,6 @@ WHERE {
   GRAPH <%= ontology[:taxonomy] %> { ?taxonomy_id rdfs:label ?taxonomy_name }
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?taxonomy_id .
-    ?togogenome rdfs:seeAlso ?uniprot_id .
-    ?uniprot_id rdfs:seeAlso ?uniprot_up .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
-  GRAPH <%= ontology[:uniprot] %> { ?uniprot_up up:recommendedName/up:fullName ?recommended_name }
 } LIMIT <%= limit %> OFFSET <%= offset %>

--- a/app/views/sparql_templates/report_type/genes/has_tax_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/has_tax_condition.rq.erb
@@ -2,7 +2,6 @@ DEFINE sql:select-option "order"
 <%= prefix[:mccv] %>
 <%= prefix[:meo] %>
 <%= prefix[:mpo] %>
-<%= prefix[:up] %>
 
 <%= select_clause %>
 WHERE {
@@ -10,10 +9,8 @@ WHERE {
   GRAPH <%= ontology[:taxonomy] %> { ?taxonomy_id rdfs:label ?taxonomy_name }
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?taxonomy_id .
-    ?togogenome rdfs:seeAlso ?uniprot_id .
-    ?uniprot_id rdfs:seeAlso ?uniprot_up .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
-  GRAPH <%= ontology[:uniprot] %> { ?uniprot_up up:recommendedName/up:fullName ?recommended_name }
   <% unless meo_id.empty? %>
     VALUES ?gold_meo { meo:MEO_0000437 meo:MEO_0000440 }
     GRAPH <%= ontology[:gold] %> {

--- a/app/views/sparql_templates/report_type/genes/init_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/init_condition.rq.erb
@@ -2,7 +2,6 @@ DEFINE sql:select-option "order"
 <%= prefix[:mccv] %>
 <%= prefix[:meo] %>
 <%= prefix[:mpo] %>
-<%= prefix[:up] %>
 
 <%= select_clause %>
 WHERE {
@@ -10,8 +9,6 @@ WHERE {
   GRAPH <%= ontology[:taxonomy] %> { ?taxonomy_id rdfs:label ?taxonomy_name }
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?taxonomy_id .
-    ?togogenome rdfs:seeAlso ?uniprot_id .
-    ?uniprot_id rdfs:seeAlso ?uniprot_up .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
-  GRAPH <%= ontology[:uniprot] %> { ?uniprot_up up:recommendedName/up:fullName ?recommended_name }
 } LIMIT <%= limit %> OFFSET <%= offset %>

--- a/app/views/sparql_templates/report_type/genes/proteins.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/proteins.rq.erb
@@ -6,7 +6,8 @@ FROM <%= ontology[:tgup] %>
 FROM <%= ontology[:uniprot] %>
 FROM <%= ontology[:go] %>
 WHERE {
-  VALUES ?gene { <%= genes %> }
+  ?gene skos:exactMatch ?refseq_gene .
+  FILTER (?gene IN( <%= genes %> ) )
   ?gene rdfs:seeAlso ?uniprot_id .
   ?uniprot_id rdf:type <http://identifiers.org/uniprot> .
   ?uniprot_id rdfs:seeAlso ?uniprot_up .

--- a/app/views/sparql_templates/report_type/genes/proteins.rq.erb
+++ b/app/views/sparql_templates/report_type/genes/proteins.rq.erb
@@ -11,5 +11,7 @@ WHERE {
   ?uniprot_id rdf:type <http://identifiers.org/uniprot> .
   ?uniprot_id rdfs:seeAlso ?uniprot_up .
   ?uniprot_up rdf:type <http://purl.uniprot.org/core/Protein> .
-  ?uniprot_up up:recommendedName/up:fullName ?recommended_name.
+  OPTIONAL {
+    ?uniprot_up up:recommendedName/up:fullName ?recommended_name.
+  }
 }

--- a/app/views/sparql_templates/report_type/organisms/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/organisms/has_go_condition.rq.erb
@@ -20,6 +20,7 @@ WHERE {
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?uniprot_id .
     ?togogenome rdfs:seeAlso ?taxonomy_id .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
 
   <% if tax_id.present? %>

--- a/app/views/sparql_templates/report_type/phenotypes/has_go_condition.rq.erb
+++ b/app/views/sparql_templates/report_type/phenotypes/has_go_condition.rq.erb
@@ -20,6 +20,7 @@ WHERE {
   GRAPH <%= ontology[:tgup] %> {
     ?togogenome rdfs:seeAlso ?uniprot_id .
     ?togogenome rdfs:seeAlso ?taxonomy_id .
+    ?togogenome skos:exactMatch ?refseq_gene .
   }
   <% if tax_id.present? %>
     GRAPH <%= ontology[:tgtax] %> { ?taxonomy_id rdfs:subClassOf <<%= tax_id %>> }

--- a/spec/models/report_type/base_spec.rb
+++ b/spec/models/report_type/base_spec.rb
@@ -7,7 +7,7 @@ describe ReportType::Base do
     context "初期表示の場合" do
       context "Gene" do
         subject { ReportType::Gene.count() }
-        it { subject.should eq("1724902") }
+        it { subject.should eq("17099130") }
       end
 
       context "Organism" do


### PR DESCRIPTION
- プロテイン名があるという条件を除いた
  - `?uniprot_up up:recommendedName/up:fullName ?recommended_name .`
- tgup グラフの中で、uniprot の id から togogenome の URL を求めていた部分を辞めた
- skos:exactMatch 述語を付けた(何の情報も無いncRNAのカウントに影響)
