### PR TITLE
GO の候補が 15件より少なくなっていたのを修正

### DIFF
--- a/app/models/facets/gene_ontology.rb
+++ b/app/models/facets/gene_ontology.rb
@@ -15,7 +15,7 @@ module Facets
               SELECT DISTINCT ?target ?name ?link ?path ?step
               WHERE {
                 {
-                  SELECT DISTINCT ?target ?name ?parent
+                  SELECT DISTINCT ?target ?name SAMPLE(?parent) AS ?parent
                   WHERE {
                     FILTER regex(?name, "#{word}", "i") .
                     ?target rdfs:label ?name .
@@ -24,6 +24,8 @@ module Facets
                     ?target rdfs:subClassOf* ?parent .
                     ?parent rdfs:subClassOf <#{root_uri}> .
                   }
+                  GROUP BY ?target ?name
+                  ORDER BY ?name
                   LIMIT 15
                 }
                 ?target rdfs:subClassOf ?parent  OPTION (TRANSITIVE, T_DISTINCT, T_EXISTS, T_DIRECTION 1, T_IN(?target), T_OUT(?parent), T_MIN(0), T_STEP(?target) AS ?link, T_STEP("path_id") AS ?path , T_STEP('step_no') AS ?step ) .


### PR DESCRIPTION
#64  にて、`?parent` を外の絞り込みで使うために、SELECT の対象にしたら、
(データ構造上正しいのだだ) 同じ ?target, ?name が同じでも違う ?parent のものもあるため、
それらを含め15件になってしまい、その後の処理で削ぎ落とされていた。

?parent は、特に意識せずどれか1つをという話だったので、
SAMPLE で任意の1個を選ぶように変えた
