### PR TITLE
change d3.xhr() to d3.json

### DIFF
--- a/app/assets/javascripts/d3sparql.js
+++ b/app/assets/javascripts/d3sparql.js
@@ -60,10 +60,12 @@ d3sparql.query = function(endpoint, sparql, callback) {
   if (d3sparql.debug) { console.log(endpoint) }
   if (d3sparql.debug) { console.log(url) }
   var mime = "application/sparql-results+json"
-  d3.xhr(url, mime, function(request) {
-    var json = request.responseText
-    if (d3sparql.debug) { console.log(json) }
-    callback(JSON.parse(json))
+  d3.json(url)
+    .header("Accept", mime)
+    .get(function(error, request) {
+       var json = request
+       if (d3sparql.debug) { console.log(json) }
+       callback(json)
   })
 /*
   d3.json(url, function(error, json) {


### PR DESCRIPTION
d3.xhr() gives "\*/\*" at the end of Accept header even if mimetype is specified.
````
accept: application/sparql-results+json,*/*
````
When use sparql-proxy as an endpoint, this accept header will be interpreted as accepting html format, and the sparql-proxy will be returned response as HTML text.
https://github.com/dbcls/sparql-proxy/blob/c833708c02fc251fafe593a9fe5f823e4a3f0e2b/src/server.mjs#L85
For this reason, I modified d3.xhr() to d3.json() to specify that the client only accepts "application/sparql-results+json".